### PR TITLE
Add -std=c99 to the compiler flag because of ‘for’ loop initial declarations are only allowed in C99 or C11 mode.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CFLAGS := -D_REENTRANT -Wall -pedantic -Isrc
+CFLAGS := -D_REENTRANT -Wall -pedantic -Isrc -std=c99
 CFLAGS += -fPIC
 LDFLAGS = -lpthread
 


### PR DESCRIPTION
Add `-std=c99` to the compiler flag because of  ‘for’ loop initial declarations are only allowed in C99 or C11 mode.